### PR TITLE
Remove space from PATH setting in /etc/environment

### DIFF
--- a/source/scripts/ComputeNode.sh
+++ b/source/scripts/ComputeNode.sh
@@ -125,7 +125,7 @@ make install -j6
 chmod 4755 /opt/pbs/sbin/pbs_iff /opt/pbs/sbin/pbs_rcp
 
 # Edit path with new scheduler/python locations
-echo "export PATH=\"/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/pbs/bin:/opt/pbs/sbin:/opt/pbs/bin:/apps/python/latest/bin\" " >> /etc/environment
+echo "export PATH=\"/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/pbs/bin:/opt/pbs/sbin:/opt/pbs/bin:/apps/python/latest/bin\"" >> /etc/environment
 
 # Disable SELINUX
 sed -i 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/selinux/config

--- a/source/scripts/Scheduler.sh
+++ b/source/scripts/Scheduler.sh
@@ -65,7 +65,7 @@ make install
 chmod 4755 /opt/pbs/sbin/pbs_iff /opt/pbs/sbin/pbs_rcp
 
 # Edit path with new scheduler/python locations
-echo "export PATH=\"/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/pbs/bin:/opt/pbs/sbin:/opt/pbs/bin:/apps/python/latest/bin\" " >> /etc/environment
+echo "export PATH=\"/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin:/opt/pbs/bin:/opt/pbs/sbin:/opt/pbs/bin:/apps/python/latest/bin\"" >> /etc/environment
 
 # Default AWS Resources
 cat <<EOF >>/var/spool/pbs/server_priv/resourcedef


### PR DESCRIPTION
Issue #4

ComputeNode.sh and Scheduler.sh create /etc/environment with
a space at the end of the PATH value. This results in a corrupt
PATH value on the compute node, where it contains a double-quote
and a space. This patch removes the trailing space from PATH's
value in /etc/environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
