### PR TITLE
Use /dev/md0 as the block device for raid instance storage scratch

### DIFF
--- a/source/scripts/ComputeNode.sh
+++ b/source/scripts/ComputeNode.sh
@@ -100,7 +100,7 @@ else
             for dev in ${VOLUME_LIST[@]} ; do dd if=/dev/zero of=$dev bs=1M count=1 ; done
             echo yes | mdadm --create -f --verbose --level=0 --raid-devices=$VOLUME_COUNT /dev/$DEVICE_NAME ${VOLUME_LIST[@]}
             mkfs -t ext4 /dev/$DEVICE_NAME
-            echo "/dev/md/0_0 /scratch ext4 defaults 0 0" >> /etc/fstab
+            echo "/dev/md0 /scratch ext4 defaults 0 0" >> /etc/fstab
         else
             echo "All volumes detected already have a partition or mount point and can't be used as scratch devices"
 	    fi


### PR DESCRIPTION
Issue #6

ComputeNode.sh configured /etc/fstab to mount /dev/md/0_0 as /scratch
when raid instance storage is used for scratch. This device name is
incorrect and causes the compute node to hang on reboot. This patch
corrects the device name configured in /etc/fstab to /dev/md0.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
