### PR TITLE
Correct validation of fsx_lustre_size in add_nodes.py

### DIFF
--- a/source/soca/cluster_manager/add_nodes.py
+++ b/source/soca/cluster_manager/add_nodes.py
@@ -85,7 +85,7 @@ def main(instance_type,
                     fsx_lustre_size = 1200
                 else:
                     fsx_lustre_capacity_allowed = [1200, 2400, 3600, 7200, 10800]
-                    if fsx_lustre_size not in fsx_lustre_capacity_allowed:
+                    if int(fsx_lustre_size) not in fsx_lustre_capacity_allowed:
                         return {'success': False,
                                 'error': 'fsx_lustre_size must be: 1200, 2400, 3600, 7200, 10800'}
 


### PR DESCRIPTION
Issue #9

add_nodes.py validates the value of fsx_lustre_size by
looking for it in an array of integers. The value is
a string. This patch converts the value to int for purposes
of comparison against the validation array.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
