### PR TITLE
Adding support for ca-central-1 (added 3 AZ support as of 3/30/20)

### DIFF
--- a/source/install-with-existing-resources.template
+++ b/source/install-with-existing-resources.template
@@ -318,9 +318,7 @@ Resources:
           def lambda_handler(event, context):
             region = event['ResourceProperties']['Region']
             stack_name = event['ResourceProperties']['StackName']
-            regions_blacklist = ['ca-central-1', # only_2_az
-                                'us-west-1',  # only_2_az
-                                ]
+            regions_blacklist = ['us-west-1'] # Only 2 AZ
 
             if region in regions_blacklist:
               error_message = 'Sorry, this region is not yet supported by SOCA'

--- a/source/scale-out-computing-on-aws.template
+++ b/source/scale-out-computing-on-aws.template
@@ -263,9 +263,7 @@ Resources:
           def lambda_handler(event, context):
             region = event['ResourceProperties']['Region']
             stack_name = event['ResourceProperties']['StackName']
-            regions_blacklist = ['ca-central-1', # only_2_az
-                                'us-west-1',  # only_2_az
-                                ]
+            regions_blacklist = ['us-west-1'] # Only 2 AZ
 
             if region in regions_blacklist:
               error_message = 'Sorry, this region is not yet supported by SOCA'


### PR DESCRIPTION
*Description of changes:*

Adding support for ca-central-1 region following https://aws.amazon.com/blogs/aws/now-open-third-availability-zone-in-the-aws-canada-central-region/

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
