### PR TITLE
Fix broken docs link

### DIFF
--- a/docs/tutorials/reduce-compute-node-launch-time-with-custom-ami.md
+++ b/docs/tutorials/reduce-compute-node-launch-time-with-custom-ami.md
@@ -55,7 +55,7 @@ You can pre-install the packages listed on [https://github.com/awslabs/scale-out
         - `yum install -y $(echo ${SSSD_PKGS[*]})`
     
     ____
-    [Here is an example](https://github.com/awslabs/scale-out-computing-on-aws/blob/master/source/scripts/ComputeNode.sh#L26) of how you can install packages listed in an array in bash.
+    [Here is an example](https://github.com/awslabs/scale-out-computing-on-aws/blob/master/source/scripts/Scheduler.sh#L34) of how you can install packages listed in an array in bash.
 
 
 


### PR DESCRIPTION
Link to [ComputeNode.sh#L26](https://github.com/awslabs/scale-out-computing-on-aws/blob/master/source/scripts/ComputeNode.sh#L26) was dead but it appears [Scheduler.sh#L34](https://github.com/awslabs/scale-out-computing-on-aws/blob/master/source/scripts/Scheduler.sh#L34) does the same thing. 

I checked all other links on this page and they're working.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
