### PR TITLE
Issue 28: don't scale fsx for lustre cost estimate by node count

### DIFF
--- a/source/soca/cluster_web_ui/api/v1/system/aws_price.py
+++ b/source/soca/cluster_web_ui/api/v1/system/aws_price.py
@@ -143,8 +143,8 @@ class AwsPrice(Resource):
         sim_cost["scratch_size"] = "%.3f" % ((scratch_size * EBS_GP2_STORAGE_BASELINE * (walltime * 3600) / (86400 * 30)) * nodect)
         sim_cost["root_size"] = "%.3f" % ((root_size * EBS_GP2_STORAGE_BASELINE * (walltime * 3600) / (86400 * 30)) * nodect)
 
-        # Calculate FSx Storage (storage * ebs_price * sim_time_in_secs / (second_in_a_day * 30 days) * number of nodes
-        sim_cost["fsx_capacity"] = "%.3f" % ((fsx_storage * FSX_STORAGE_BASELINE * (walltime * 3600) / (86400 * 30)) * nodect)
+        # Calculate FSx Storage (storage * ebs_price * sim_time_in_secs / (second_in_a_day * 30 days)
+        sim_cost["fsx_capacity"] = "%.3f" % (fsx_storage * FSX_STORAGE_BASELINE * (walltime * 3600) / (86400 * 30))
 
         # Calculate Compute
         try:


### PR DESCRIPTION
Issue #28 

Don't scale the FSx for Lustre cost estimate by the node count.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
