### PR TITLE
Support use of scratch_opts in the cost estimator

### DIFF
--- a/source/soca/cluster_web_ui/templates/submit_job_selected_application.html
+++ b/source/soca/cluster_web_ui/templates/submit_job_selected_application.html
@@ -146,6 +146,22 @@
                   var fsx_capacity = $("#fsx_capacity").val() || 0;
                   var walltime = $("#wall_time").val() || "01:00:00";
                   var cpus = $("#cpus").val() || 1;
+                  var scratch_opts = $("#scratch_opts").val() || 0;
+
+                  if (scratch_opts) {
+                      scratch_opts.split(',').forEach(function (item, index) {
+                          var opt = item.split('=')
+                          if (opt.length > 1) {
+                              var k = opt[0]
+                              var v = opt[1]
+                              if (k == 'scratch_size') {
+                                  scratch_size = v
+                              } else if (k == 'fsx_lustre_size') {
+                                  fsx_capacity = v
+                              }
+                          }
+                      })
+                  }
 
                   $("#cost_result").html('<div align="center"><i class="fas fa-spinner fa-5x"></i></div><h3><br> Please wait while we estimate the price of this job ... </h3>'),
 
@@ -155,7 +171,8 @@
                           "root_size": root_size,
                           "fsx_capacity": fsx_capacity,
                           "cpus": cpus,
-                          "wall_time": walltime
+                          "wall_time": walltime,
+                          "scratch_opts": scratch_opts
                       }, function (data) {
 
                           cost_data = jQuery.parseJSON(JSON.stringify(data));


### PR DESCRIPTION
Issue #30 

1. `aws_price.py` - parse the `scratch_opts` argument's value as a comma-separated list of key=value elements. `scratch_size`, `scratch_iops`, `fsx_lustre_size` and `fsx_lustre_deployment_type` are used to calculate the storage cost estimate. This is backward compatible with the existing storage cost estimate parameters.
2. `submit_job_selected_application.html` - if the form has a `scratch_opts` element, parse its selected value to update `scratch_size` and `fsx_capacity` vars. This is backward compatible with the existing storage cost estimate form elements.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
