### PR TITLE
Update integration-ec2-job-parameters.md

### DIFF
--- a/docs/tutorials/integration-ec2-job-parameters.md
+++ b/docs/tutorials/integration-ec2-job-parameters.md
@@ -191,12 +191,13 @@ Below is a list of parameters you can specify when you request your simulation t
 
 ##### Mount existing FSx
 
-- Description: Mount an existing FSx to all compute nodes if `fsx_lustre` points to a FSx filesystem ID
-- Example: `-l fsx_lustre=fs-xxxx`
+- Description: Mount an existing FSx to all compute nodes if `fsx_lustre` points to a FSx filesystem's DNS name
+- Example: `-l fsx_lustre=fs-xxxx.fsx.region.amazonaws.com`
 
 !!!info   
     - FSx partitions are mounted as `/fsx`. This can be changed if needed 
     - Make sure your FSx for Luster configuration is correct (use SOCA VPC and correct IAM roles)
+    - [Make sure to use the Filesytem's DNS name](../../storage/launch-job-with-fsx/#how-to-connect-to-a-permanentexisting-fsx)
 
 
 #### fsx_lustre_size


### PR DESCRIPTION
Change FSx ID to DNS name.

You need the DNS name for this to work, see https://github.com/awslabs/scale-out-computing-on-aws/blob/master/source/soca/cluster_node_bootstrap/ComputeNodePostReboot.sh#L90

It wouldn't be hard to switch this to take the FSx id instead which imho would make a lot more sense, but that's outside of the scope of this PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
