### PR TITLE
Fix IAM Role and Fix Amazon Linux 2

### DIFF
--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -139,7 +139,8 @@
                 "s3:createBucket",
                 "ecr:createRepository",
                 "ecr:deleteRepository",
-                "s3:PutEncryptionConfiguration"
+                "s3:PutEncryptionConfiguration",
+                "s3:PutBucketVersioning"
             ],
             "Resource": "*"
         },

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -204,7 +204,8 @@
                 "route53resolver:DisassociateResolverRule",
                 "secretsmanager:DeleteSecret",
                 "s3:DeleteBucketPolicy",
-                "ecr:deleteRepository"
+                "ecr:deleteRepository",
+                "iam:DeleteServiceLinkedRole"
             ],
             "Resource": "*"
         }

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -139,7 +139,7 @@
                 "s3:createBucket",
                 "ecr:createRepository",
                 "ecr:deleteRepository",
-                "s3:setbucketencryption"
+                "s3:PutEncryptionConfiguration"
             ],
             "Resource": "*"
         },

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -138,6 +138,7 @@
                 "ssm:deleteParameter",
                 "s3:createBucket",
                 "ecr:createRepository",
+                "ecr:deleteRepository",
                 "s3:setbucketencryption"
             ],
             "Resource": "*"

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -135,7 +135,10 @@
                 "secretsmanager:TagResource",
                 "sts:DecodeAuthorizationMessage",
                 "ssm:PutParameter",
-                "s3:createBucket"
+                "ssm:deleteParameter",
+                "s3:createBucket",
+                "ecr:createRepository",
+                "s3:setbucketencryption"
             ],
             "Resource": "*"
         },

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -138,10 +138,13 @@
                 "ssm:deleteParameter",
                 "s3:createBucket",
                 "ecr:createRepository",
-                "ecr:deleteRepository",
                 "s3:PutEncryptionConfiguration",
                 "s3:PutBucketVersioning",
-                "s3:PutBucketPublicAccessBlock"
+                "s3:PutBucketPublicAccessBlock",
+                "ecr:DescribeRepositories",
+                "s3:PutBucketPolicy",
+                "ssm:GetParameters",
+                "ssm:GetParameter"
             ],
             "Resource": "*"
         },
@@ -196,7 +199,9 @@
                 "route53resolver:DeleteResolverEndpoint",
                 "route53resolver:DeleteResolverRule",
                 "route53resolver:DisassociateResolverRule",
-                "secretsmanager:DeleteSecret"
+                "secretsmanager:DeleteSecret",
+                "s3:DeleteBucketPolicy",
+                "ecr:deleteRepository"
             ],
             "Resource": "*"
         }

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -133,7 +133,9 @@
                 "s3:ListBucket",
                 "secretsmanager:CreateSecret",
                 "secretsmanager:TagResource",
-                "sts:DecodeAuthorizationMessage"
+                "sts:DecodeAuthorizationMessage",
+                "ssm:PutParameter",
+                "s3:createBucket"
             ],
             "Resource": "*"
         },

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -144,7 +144,10 @@
                 "ecr:DescribeRepositories",
                 "s3:PutBucketPolicy",
                 "ssm:GetParameters",
-                "ssm:GetParameter"
+                "ssm:GetParameter",
+                "iam:CreateServiceLinkedRole",
+                "ec2:DescribeAccountAttributes",
+                "es:CreateServiceLinkedRole"
             ],
             "Resource": "*"
         },

--- a/installer/SOCAInstallerIamPolicy.json
+++ b/installer/SOCAInstallerIamPolicy.json
@@ -140,7 +140,8 @@
                 "ecr:createRepository",
                 "ecr:deleteRepository",
                 "s3:PutEncryptionConfiguration",
-                "s3:PutBucketVersioning"
+                "s3:PutBucketVersioning",
+                "s3:PutBucketPublicAccessBlock"
             ],
             "Resource": "*"
         },

--- a/installer/default_config.yml
+++ b/installer/default_config.yml
@@ -156,7 +156,7 @@ RegionMap:
     centos7: ami-00e87074e52e6c9f9
     rhel7: ami-08a7d2bfef687328f
   us-east-2:
-    amazonlinux2: ami-0a0ad6b70e61be944
+    amazonlinux2: ami-066157edddaec5e49
     centos7: ami-00f8e2c955f7ffa9b
     rhel7: ami-0e166e72fda655c63
   us-west-1:

--- a/source/scripts/Scheduler.sh
+++ b/source/scripts/Scheduler.sh
@@ -40,6 +40,8 @@ echo $SERVER_IP $SERVER_HOSTNAME $SERVER_HOSTNAME_ALT >> /etc/hosts
 # Install Epel repo
 if [[ $SOCA_BASE_OS == "amazonlinux2" ]]; then
   sudo amazon-linux-extras install -y epel
+  sudo yum groupinstall "Development Tools" -y
+  curl -sL https://rpm.nodesource.com/setup_16.x | sudo bash -
 elif [[ $SOCA_BASE_OS == "centos7" ]]; then
   yum -y install epel-release
 else


### PR DESCRIPTION
Could not deploy CDK and SOCA without changes to IAM role. Permissions fixed in example IAM policy json.

Amazon Linux would not deploy because of lack of Dev tools, could not compile Python, OpenPBS, OpenMPI, fixed in Scheduler.sh

NodeJS 16 would not install from epel on AML2 because of libuv dependancy. Installing NodeJS 16 first then pulling required packages from repos.

Updated base AMI for us-east-2 to latest AL2.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.