### PR TITLE
fix subnet_id in views for DCV nodes

### DIFF
--- a/source/soca/cluster_web_ui/views/remote_desktop.py
+++ b/source/soca/cluster_web_ui/views/remote_desktop.py
@@ -98,6 +98,7 @@ def create():
                                 "disk_size": request.form["disk_size"],
                                 "session_name": request.form["session_name"],
                                 "instance_ami": request.form["instance_ami"],
+                                "subnet_id": request.form["subnet_id"],
                                 "hibernate": request.form["hibernate"]},
                           verify=False)  # nosec
     if create_desktop.status_code == 200:


### PR DESCRIPTION
*Issue #, if available:*

DCV nodes will not launch in a specific specified subnet because views does not collect the arg from the form

*Description of changes:*

Add the arg in views to collect from the form

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.