### PR TITLE
Add support for ap-south-2 (Hyderabad)

### DIFF
--- a/installer/default_config.yml
+++ b/installer/default_config.yml
@@ -107,6 +107,10 @@ RegionMap:
     amazonlinux2: ami-08c6724c280604575
     centos7: ami-0ffc7af9c06de0077
     rhel7: ami-024685afee5678595
+  ap-south-2:
+    amazonlinux2: ami-05c8b152469056282
+    centos7: ami-0fbb3b69d32a39167
+    rhel7: ami-06ed2b77cde70d481
   ap-southeast-1:
     amazonlinux2: ami-049f20cccc294bb90
     centos7: ami-0adfdaea54d40922b


### PR DESCRIPTION
Add AMIs for the region into default_config.yml

Deployment failed with the following error:

```
soca-example-hyd failed: Error [ValidationError]: Template format error: Unrecognized resource types: [AWS::Backup::BackupPlan, AWS::Backup::BackupSelection, AWS::Backup::BackupVault]
```

It looks like not all of the services required by SOCA are available in the new region.

Resolves #90

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.